### PR TITLE
Pulling Councilor Information for IHS Students

### DIFF
--- a/index.py
+++ b/index.py
@@ -26,7 +26,8 @@ def getInfo(username, password):
         registrationDOM = getPage(username, password, REGISTRATION_URL)
 
         parser = createBS4Parser(registrationDOM.text)
-        studentID = parser.find(id="plnMain_lblRegStudentID").text
+        #studentID = parser.find(id="plnMain_lblRegStudentID").text
+        studentID = getPage(username, password, STUDENTSCHEDULE_URL).find(id="plnMain_lblStudentIDValue").text
         studentName = parser.find(id="plnMain_lblRegStudentName").text
         studentBirthDate = parser.find(id="plnMain_lblBirthDate").text
         studentCounselor = parser.find(id="plnMain_lblCounselor").text


### PR DESCRIPTION
The previous request pulled the student id from the registration page, but for some schools including Independence High School, the Student ID is not available from the registration page. This information, though, is accessible through the schedule information. The path for the correct student id without error has been provided.